### PR TITLE
succedded in making the testWithdrawWithMultipleFundersCheaper test f…

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,1 +1,9 @@
-FundMeTest:testWithdrawWithMultipleFunders() (gas: 489930);
+FundMeTest:testAddressFunderToArrayOfFunders() (gas: 99736)
+FundMeTest:testFundFailWithoutEnoughEth() (gas: 22989)
+FundMeTest:testFundUpdatesFundedDataStructure() (gas: 99432)
+FundMeTest:testMinimumUsdIsFive() (gas: 5425)
+FundMeTest:testOnlyOwnerCanWithdraw() (gas: 101575)
+FundMeTest:testPriceFeedVersionIsAccurate() (gas: 14379)
+FundMeTest:testWithdrawWithASingleFunder() (gas: 86433)
+FundMeTest:testWithdrawWithMultipleFunders() (gas: 490176)
+FundMeTest:testWithdrawWithMultipleFundersCheaper() (gas: 489328)

--- a/test/FundMeTest.t.sol
+++ b/test/FundMeTest.t.sol
@@ -101,4 +101,24 @@ contract FundMeTest is Test {
         assert(address(fundMe).balance == 0);
         assert(startOwnerBalance + startContractBalace == fundMe.getOwner().balance);
     }
+
+    function testWithdrawWithMultipleFundersCheaper() public funded {
+        uint160 numberOfFunders = 10;
+        uint160 indexOfFunders = 1;
+
+        for(uint160 i = indexOfFunders; i < numberOfFunders; i++){
+            hoax(address(i), SEND_VALUE);
+            fundMe.fund{value: SEND_VALUE}();
+        }
+
+        uint256 startOwnerBalance = fundMe.getOwner().balance;
+        uint256 startContractBalace = address(fundMe).balance;
+
+        vm.startPrank(fundMe.getOwner());
+        fundMe.cheapWithdraw();
+        vm.stopPrank();
+
+        assert(address(fundMe).balance == 0);
+        assert(startOwnerBalance + startContractBalace == fundMe.getOwner().balance);
+    }
 }


### PR DESCRIPTION
…unction and the cheapWithdraw function in the fundMe Contract cheaper by changing the variables it uses from storage to memory variables